### PR TITLE
Add tests based on passport-facebook testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+coverage/
+
+# Mac OS X
+.DS_Store
+
+# Node.js
+node_modules
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -3,13 +3,22 @@
   "version": "1.0.0",
   "description": "An OAuth2 passport strategy for Fitbit",
   "main": "lib/index.js",
+  "scripts": {
+    "test": "./node_modules/.bin/mocha --require test/bootstrap/node test/*.test.js",
+    "cover": "./node_modules/.bin/istanbul cover --preserve-comments ./node_modules/.bin/_mocha -- --reporter spec --require test/bootstrap/node test/*.test.js"
+  },
   "directories": {
     "example": "examples"
   },
   "dependencies": {
     "passport-oauth2": "^1.1.2"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "chai-passport-strategy": "^1.0.0",
+    "istanbul": "^0.4.4",
+    "mocha": "^2.5.3"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thegameofcode/passport-fitbit-oauth2.git"

--- a/test/bootstrap/node.js
+++ b/test/bootstrap/node.js
@@ -1,0 +1,5 @@
+var chai = require('chai');
+
+chai.use(require('chai-passport-strategy'));
+
+global.expect = chai.expect;

--- a/test/oauth2.test.js
+++ b/test/oauth2.test.js
@@ -1,0 +1,126 @@
+/* global describe, it, expect, before */
+/* jshint expr: true */
+
+var chai = require('chai')
+  , Strategy = require('../lib').FitbitOAuth2Strategy;
+
+//Note: Based on https://github.com/jaredhanson/passport-facebook/blob/b4f1cff3c7391122535e0837ffcc63bd1d2a4a79/test/strategy.test.js
+describe('Strategy', function() {
+    
+  describe('constructed', function() {
+    var strategy = new Strategy({
+        clientID: 'ABC123',
+        clientSecret: 'secret'
+      },
+      function() {});
+    
+    it('should be named fitbit', function() {
+      expect(strategy.name).to.equal('fitbit');
+    });
+  });
+
+  describe('constructed with undefined options', function() {
+    it('should throw', function() {
+      expect(function() {
+        var strategy = new Strategy(undefined, function(){});
+      }).to.throw(Error);
+    });
+  });
+
+  describe('authorization request without options', function() {
+    var strategy = new Strategy({
+      clientID: 'ABC123',
+      clientSecret: 'secret'
+    }, function() {});
+
+    var url;
+
+    before(function(done) {
+      chai.passport.use(strategy)
+        .redirect(function(u) {
+          url = u;
+          done();
+        })
+        .req(function(req) {
+        })
+        .authenticate();
+    });
+
+    it('should be redirected', function() {
+      expect(url).to.equal('https://www.fitbit.com/oauth2/authorize?response_type=code&client_id=ABC123');
+    });
+  });
+
+  describe('authorization request with extra parameters', function() {
+    var strategy = new Strategy({
+        clientID: 'ABC123',
+        clientSecret: 'secret'
+      }, function() {});
+    
+    var url;
+
+    before(function(done) {
+      chai.passport.use(strategy)
+        .redirect(function(u) {
+          url = u;
+          done();
+        })
+        .req(function(req) {
+        })
+        .authenticate({ foo: 'bar' });
+    });
+
+    it('should be redirected', function() {
+      expect(url).to.equal('https://www.fitbit.com/oauth2/authorize?foo=bar&response_type=code&client_id=ABC123');
+    });
+  });
+
+  describe('authorization request with scopes', function() {
+    var strategy = new Strategy({
+      clientID: 'ABC123',
+      clientSecret: 'secret'
+    }, function() {});
+
+    var url;
+
+    before(function(done) {
+      chai.passport.use(strategy)
+        .redirect(function(u) {
+          url = u;
+          done();
+        })
+        .req(function(req) {
+        })
+        .authenticate({ scope: 'weight profile' });
+    });
+
+    it('should be redirected', function() {
+      expect(url).to.equal('https://www.fitbit.com/oauth2/authorize?scope=weight%20profile&response_type=code&client_id=ABC123');
+    });
+  });
+
+  describe('authorization request with scopes in array format', function() {
+    var strategy = new Strategy({
+      clientID: 'ABC123',
+      clientSecret: 'secret'
+    }, function() {});
+
+    var url;
+
+    before(function(done) {
+      chai.passport.use(strategy)
+        .redirect(function(u) {
+          url = u;
+          done();
+        })
+        .req(function(req) {
+        })
+        .authenticate({ scope: ['weight','profile'] });
+    });
+
+    it('should be redirected', function() {
+      expect(url).to.equal('https://www.fitbit.com/oauth2/authorize?scope=weight%20profile&response_type=code&client_id=ABC123');
+    });
+  });
+
+});

--- a/test/strategy.profile.test.js
+++ b/test/strategy.profile.test.js
@@ -1,0 +1,152 @@
+/* global describe, it, before, expect */
+/* jshint expr: true */
+
+var Strategy = require('../lib').FitbitOAuth2Strategy;
+
+//Note: Based on https://github.com/jaredhanson/passport-facebook/blob/35662267f19773314eabc3976906403564426b20/test/strategy.profile.test.js
+describe('Strategy#userProfile', function() {
+    
+  describe('fetched from default endpoint', function() {
+    var strategy = new Strategy({
+        clientID: 'ABC123',
+        clientSecret: 'secret'
+      }, function() {});
+
+    var fitbitProfileRaw = '{"user":{"age":36,"avatar":"https://static0.fitbit.com/images/profile/defaultProfile_100_male.gif","avatar150":"https://static0.fitbit.com/images/profile/defaultProfile_150_male.gif","averageDailySteps":0,"corporate":false,"corporateAdmin":false,"country":"ES","dateOfBirth":"1980-02-01","displayName":"Homer","distanceUnit":"METRIC","encodedId":"AAA111","features":{"exerciseGoal":true},"foodsLocale":"es_ES","fullName":"Homer Simpson","gender":"MALE","glucoseUnit":"METRIC","height":172,"heightUnit":"METRIC","locale":"es_ES","memberSince":"2016-06-09","offsetFromUTCMillis":7200000,"startDayOfWeek":"MONDAY","strideLengthRunning":89.5,"strideLengthRunningType":"default","strideLengthWalking":71.4,"strideLengthWalkingType":"default","timezone":"Europe/Madrid","topBadges":[],"waterUnit":"METRIC","waterUnitName":"ml","weight":67,"weightUnit":"METRIC"}}';
+
+    strategy._oauth2.get = function(url, accessToken, callback) {
+      expect(url).to.equal('https://api.fitbit.com/1/user/-/profile.json');
+      expect(accessToken).to.equal('token');
+      callback(null, fitbitProfileRaw, undefined);
+
+    };
+
+    var useAuthorizationHeaderforGET_called = false;
+    strategy._oauth2.useAuthorizationHeaderforGET = function(use) {
+      expect(use).to.be.true;
+      useAuthorizationHeaderforGET_called = true;
+    };
+
+    var profile;
+    
+    before(function(done) {
+      strategy.userProfile('token', function(err, p) {
+        if (err) { return done(err); }
+        profile = p;
+        done();
+      });
+    });
+
+    it('should use auth header for get', function() {
+      expect(useAuthorizationHeaderforGET_called).to.be.true;
+    });
+    
+    it('should parse profile', function() {
+      expect(profile.provider).to.equal('fitbit');
+      
+      expect(profile.id).to.equal('AAA111');
+      expect(profile.displayName).to.equal('Homer');
+    });
+    
+    it('should set json property', function() {
+      expect(profile._json).to.be.eql(JSON.parse(fitbitProfileRaw));
+    });
+  });
+  
+  describe('error caused by invalid token', function() {
+    var strategy =  new Strategy({
+        clientID: 'ABC123',
+        clientSecret: 'secret'
+      }, function() {});
+  
+    strategy._oauth2.get = function(url, accessToken, callback) {
+      var body = '{"errors":[{"errorType":"invalid_token","message":"Access token invalid: token. Visit https://dev.fitbit.com/docs/oauth2 for more information on the Fitbit Web API authorization process."}],"success":false}';
+  
+      callback({ statusCode: 401, data: body });
+    };
+      
+    var err, profile;
+    before(function(done) {
+      strategy.userProfile('token', function(e, p) {
+        err = e;
+        profile = p;
+        done();
+      });
+    });
+
+    it('should error', function() {
+      //TODO: Library should check Fitbit error, similar to: https://github.com/jaredhanson/passport-fitbit/blob/master/lib/strategy.js#L86
+      expect(err).to.be.an.instanceOf(Error);
+      expect(err.constructor.name).to.equal('InternalOAuthError');
+      expect(err.message).to.equal('failed to fetch user profile');
+    });
+
+    it('should not load profile', function() {
+      expect(profile).to.be.undefined;
+    });
+
+  });
+  
+  describe('error caused by malformed response', function() {
+    var strategy =  new Strategy({
+        clientID: 'ABC123',
+        clientSecret: 'secret'
+      }, function() {});
+  
+    strategy._oauth2.get = function(url, accessToken, callback) {
+      var body = 'Hello, world.';
+      callback(null, body, undefined);
+    };
+    
+    var err, profile;
+    before(function(done) {
+      strategy.userProfile('token', function(e, p) {
+        err = e;
+        profile = p;
+        done();
+      });
+    });
+  
+    it('should error', function() {
+      //TODO: Library should raise specific error about parsing
+      expect(err).to.be.an.instanceOf(SyntaxError);
+    });
+
+    it('should not load profile', function() {
+      expect(profile).to.be.undefined;
+    });
+  });
+  
+  describe('internal error', function() {
+    var strategy = new Strategy({
+        clientID: 'ABC123',
+        clientSecret: 'secret'
+      }, function() {});
+  
+    strategy._oauth2.get = function(url, accessToken, callback) {
+      return callback(new Error('something went wrong'));
+    };
+    
+    var err, profile;
+    before(function(done) {
+      strategy.userProfile('wrong-token', function(e, p) {
+        err = e;
+        profile = p;
+        done();
+      });
+    });
+    
+    it('should error', function() {
+      expect(err).to.be.an.instanceOf(Error);
+      expect(err.constructor.name).to.equal('InternalOAuthError');
+      expect(err.message).to.equal('failed to fetch user profile');
+      expect(err.oauthError).to.be.an.instanceOf(Error);
+      expect(err.oauthError.message).to.equal('something went wrong');
+    });
+    
+    it('should not load profile', function() {
+      expect(profile).to.be.undefined;
+    });
+  });
+  
+});


### PR DESCRIPTION
This PR provide testing to the library. It is based on [passport-facebook](https://github.com/jaredhanson/passport-facebook) test suite.

I added some `//TODO` in some tests, because the library should have deeper error handling.

Two commands available:
- `npm test`: run test suite using mocha
- `npm run cover`: run test suite using mocha and creating coverage report in `coverage/lcov-report/index.html` with istanbul.

Tests:
<img width="390" alt="test suite" src="https://cloud.githubusercontent.com/assets/1424663/16451388/0467e3d2-3e03-11e6-9f70-15271a1ce595.png">

Coverage:
<img width="801" alt="coverage report" src="https://cloud.githubusercontent.com/assets/1424663/16451437/55b62a78-3e03-11e6-833c-eee6ffd4079d.png">
